### PR TITLE
feat: Add dark mode and autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <img src=https://hc-cdn.hel1.your-objectstorage.com/s/v3/d9a863f15245995c9c7ca94535221e483ec23b2c_screenshot_2025-09-21_203311.png width=400>
 <img src=https://hc-cdn.hel1.your-objectstorage.com/s/v3/c8995cdf063201d72b8311db14c9bc15c2e4c0ed_image.png width=400>
 <img src=https://hc-cdn.hel1.your-objectstorage.com/s/v3/884feae879bc1d8b02acc0b998564d3c40e6aaa3_image.png width=400>
+<img src=https://hc-cdn.hel1.your-objectstorage.com/s/v3/283f296f695d671b8344c736d316e37746f34ac9_image.png width=400>
 </div>
 <div>
 <img src=https://hc-cdn.hel1.your-objectstorage.com/s/v3/61393ba6bf243e9aba30b302e1a695a732a8b6be_image.png width=220>
@@ -23,36 +24,41 @@ Liveboard transforms your desktop into an infinite creative canvas, letting you 
 
 ## Features
 - **Infinitely Large Canvas** - Just drag it around or zoom for more space
+- **Dark Mode** - Switch the UI between light and dark mode, and your drawings will update to remain visible 
 - **Multiple Colours and Pen thicknesses** - Keep your notes and drawings visually interesting
-- **Lives on your desktop** - just minimise your window and get straight to the whiteboard
+- **Lives on your desktop** - Just minimise your window and get straight to the whiteboard
 - **Undo and Redo** - Fix up any mistakes by simply undoing your last action
 - **Pen Eraser** - Erase your pen marks simply by switching tools
 - **Shape Templates** - Use the shape tool to draw perfect shapes. Hold shift to snap to perfect circles/squares
 - **Text** - Use the text tool to write readable text on your whiteboard
 - **Fully Open-Source** - Fork the repo and implement your own new features
 
-## Usage
+## Installing
 Head over to the [releases tab](https://github.com/MadAvidCoder/Liveboard/releases), and download the relevant installer for your system, from the latest release. Run the installer *(your computer may warn you it is unverified. It's safe to manually bypass this, and feel free to check the code if you're concerned about security)*. Once you've downloaded it, run the installer, and you're good to go!
 
-There a number of different tools within Liveboard. The pen tool is used for drawing ink on the whiteboard, and the eraser for erasing it. The shape tool can be used to draw perfect shapes, saving you draw them. The text tool enables readable text to be easily created, rather than drawing it. Undo and Redo work across all actions and tools. To pan hold `Ctrl` or `Alt` and drag around. Hold shift while using the shape tool to snap ellipses and rectangles to circles and squares. Liveboard also has full touch support - use one finger to draw, and two fingers to zoom or drag.
-
 If the app doesn't auto-start, manually open it, and it should appear on your desktop. An icon will appear in the tray, from where you can control it and quit the app. To use the whiteboard, minimise your window, and start drawing!
+
+
+## Usage
+There a number of different tools within Liveboard. The pen tool is used for drawing ink on the whiteboard, and the eraser for erasing it. The shape tool can be used to draw perfect shapes, saving you from drawing them. The text tool enables readable text to be easily created, rather than hand-writing it. Undo and Redo work across all actions and tools. To pan hold `Ctrl` or `Alt` and drag around. Hold shift while using the shape tool to snap ellipses and rectangles to circles and squares. Liveboard also has full touch support - use one finger to draw, and two fingers to zoom or drag.
+
+Use the sun/moon icon in the top right corner to easily switch the UI between light and dark mode. All drawings (and this theme) should persist betewen restarts, so if you want a fresh slate, just clicker the eraser tool, and then select `Clear All` to get a blank whiteboard!
 
 **Note:** Due to security limitations set by the OS, if you use a minimise shorcut (e.g. `Win + D` or a three-finger swipe), then Liveboard will likely be hidden. You can simply use the tray icon to show it again. 
 
 ## Development
-To run Liveboard locally or contribute:
+To run Liveboard locally or test any changes you make:
 ```bash
 git clone https://github.com/MadAvidCoder/Liveboard.git
 cd Liveboard
 npm install
 npm run start # Start the development server
-npm run electron # Launch electron (if necessary)
+npm run electron # Launch electron
 ```
 To build and package it:
 ```bash
 npm run build
-npm run package # Package an electron installer for your current OS
+npm run package # Package an electron installer (targets your current OS)
 ```
 
 ## Tech Stack
@@ -60,10 +66,10 @@ npm run package # Package an electron installer for your current OS
 - **NPM** for package management
 - **Electron** for desktop app framework
 - **Electron Builder** for packaging
-- **Konva** for the infinite canvas
+- **Konva** for the infinite canvas framework
+- **GitHub Actions** for building packages for other target OSs
 
 ## License
-
 Liveboard is licensed under the [MIT License](LICENSE).
 
 You are free to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of this software. You must include the original copyright and license notice in any copies or substantial portions of the project.

--- a/main/electron.js
+++ b/main/electron.js
@@ -31,10 +31,10 @@ function createWindow() {
   });
 
   // DEV ONLY
-  win.loadURL('http://localhost:3000');
+  // win.loadURL('http://localhost:3000');
   
   // PRODUCTION ONLY
-  // win.loadFile(path.join(app.getAppPath(), 'build', 'index.html'));
+  win.loadFile(path.join(app.getAppPath(), 'build', 'index.html'));
 
   win.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
     console.error('Window failed to load:', errorDescription);

--- a/main/electron.js
+++ b/main/electron.js
@@ -23,8 +23,10 @@ function createWindow() {
     alwaysOnTop: false,
     focusable: true,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false,
+      preload: path.join(__dirname, 'preload.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false,
     },
   });
 

--- a/main/electron.js
+++ b/main/electron.js
@@ -31,10 +31,10 @@ function createWindow() {
   });
 
   // DEV ONLY
-  // win.loadURL('http://localhost:3000');
+  win.loadURL('http://localhost:3000');
   
   // PRODUCTION ONLY
-  win.loadFile(path.join(app.getAppPath(), 'build', 'index.html'));
+  // win.loadFile(path.join(app.getAppPath(), 'build', 'index.html'));
 
   win.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
     console.error('Window failed to load:', errorDescription);

--- a/main/preload.js
+++ b/main/preload.js
@@ -1,0 +1,13 @@
+const { contextBridge } = require('electron');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+contextBridge.exposeInMainWorld('liveboardAPI', {
+  autosavePath: () => path.join(os.homedir(), '.liveboard', 'autosave.json'),
+  writeFile: (filePath, data) => fs.writeFileSync(filePath, data, 'utf-8'),
+  readFile: (filePath) => fs.readFileSync(filePath, 'utf-8'),
+  fileExists: (filePath) => fs.existsSync(filePath),
+  mkdir: (dirPath) => fs.mkdirSync(dirPath, { recursive: true }),
+  dirname: (filePath) => path.dirname(filePath),
+});

--- a/public/index.html
+++ b/public/index.html
@@ -2,10 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-    <!-- WARNING: REMOVE 'unsafe-inline' BEFORE PRODUCTION -->
-     <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
+    <meta http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        script-src 'self';
+        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+        font-src 'self' https://fonts.gstatic.com;
+      ">
     <meta
       http-equiv="X-Content-Security-Policy"
       content="default-src 'self'; script-src 'self'"

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -69,6 +69,7 @@ getTextWidth.canvas = null as HTMLCanvasElement | null;
 const CANVAS_FONT = "Inter, SF Pro Display, Segoe UI, Roboto, Arial, sans-serif";
 
 const InfiniteCanvas: React.FC = () => {
+  const themePath = window.liveboardAPI.autosavePath().replace(/\.json$/, ".theme");
   const [theme, setTheme] = useState<"light" | "dark">("light");
 
   const autosavePath = window.liveboardAPI.autosavePath();
@@ -116,7 +117,33 @@ const InfiniteCanvas: React.FC = () => {
   const drawPointerId = useRef<number | null>(null);
 
   const [autosaveLoaded, setAutosaveLoaded] = useState(false);
+  const [themeLoaded, setThemeLoaded] = useState(false);
 
+  useEffect(() => {
+    try {
+      setThemeLoaded(true);
+      if (window.liveboardAPI.fileExists(themePath)) {
+        const fileContent = window.liveboardAPI.readFile(themePath);
+        if (fileContent === "light" || fileContent === "dark") {
+          setTheme(fileContent);
+        }
+      }
+    } catch (err) {
+      console.error("Theme load error:", err);
+      setThemeLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!themeLoaded) return;
+    document.documentElement.setAttribute("data-theme", theme);
+    try {
+      window.liveboardAPI.writeFile(themePath, theme);
+    } catch (err) {
+      console.error("Theme save error:", err);
+    }
+  }, [theme]);
+  
   const initialPinch = useRef<{
     center: { x: number; y: number },
     stagePos: { x: number; y: number },

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -106,8 +106,6 @@ const InfiniteCanvas: React.FC = () => {
 
   const [activeTool, setActiveTool] = useState<Tool>("pen");
   
-  const [eraserRadius] = useState(10);
-
   const stageRef = useRef<any>(null);
   
   const lastPanPos = useRef({ x: 0, y: 0 });
@@ -125,6 +123,18 @@ const InfiniteCanvas: React.FC = () => {
 
   const inputRefs = useRef<{ [id: string]: HTMLInputElement | null }>({});
   const [inputWidths, setInputWidths] = useState<{ [id: string]: number }>({});
+
+  const [eraserRadius, setEraserRadius] = useState(10);
+  const clearCanvas = () => {
+    setLines([]);
+    setTextboxes([]);
+    setShapePreview(null);
+    setUndoneLines([]);
+    setEraseBuffer([]);
+    setRedoEraseBuffer([]);
+    setUndoBuffer([]);
+    setRedoBuffer([]);
+  };
 
   const handleStageTextMouseDown = (e: any) => {
     if (activeTool !== "text") return;
@@ -607,6 +617,9 @@ const InfiniteCanvas: React.FC = () => {
         setSelectedShape={setCurrentShape}
         textFontSize={currentTextFontSize}
         setTextFontSize={setCurrentTextFontSize}
+        eraserRadius={eraserRadius}
+        setEraserRadius={setEraserRadius}
+        clearCanvas={clearCanvas}
         undo={undo}
         redo={redo}
       />

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -696,8 +696,8 @@ const InfiniteCanvas: React.FC = () => {
         height={window.innerHeight}
         baseDotSpacing={32}
         dotRadius={1.5}
-        color="#d8e1e4ff"
-        opacity={0.75}
+        color={theme === "light" ? "#d8e1e4" : "#383a43"}
+        opacity={theme === "light" ? 0.75 : 0.31}
         minScreenSpacing={16}
       />
       <Stage

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -41,7 +41,9 @@ const INITIAL_SCALE = 1;
 
 function getCanvasColor(color: string, theme: "light" | "dark") {
   const isBlack = color === "#222" || color === "#000" || color.toLowerCase() === "black";
+  const isWhite = color === "#fff" || color.toLowerCase() === "white";
   if (theme === "dark" && isBlack) return "#fff";
+  if (theme === "dark" && isWhite) return "#222";
   return color;
 }
 
@@ -658,6 +660,8 @@ const InfiniteCanvas: React.FC = () => {
         clearCanvas={clearCanvas}
         undo={undo}
         redo={redo}
+        theme={theme}
+        getCanvasColor={getCanvasColor}
       />
       <button
         className="theme-toggle-btn"

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -175,6 +175,25 @@ const InfiniteCanvas: React.FC = () => {
   }, [editingTextboxId]);
 
   useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          redo();
+        } else {
+          undo();
+        }
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'y') {
+        e.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [undoBuffer, redoBuffer, lines, textboxes]);
+
+  useEffect(() => {
     if (!editingTextboxId) return;
     const preventScroll = (e: Event) => {
       e.preventDefault();

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -39,6 +39,12 @@ type Textbox = {
 
 const INITIAL_SCALE = 1;
 
+function getCanvasColor(color: string, theme: "light" | "dark") {
+  const isBlack = color === "#222" || color === "#000" || color.toLowerCase() === "black";
+  if (theme === "dark" && isBlack) return "#fff";
+  return color;
+}
+
 function distToSegment(p: { x: number, y: number }, v: { x: number, y: number }, w: { x: number, y: number }) {
   const l2 = (v.x - w.x) ** 2 + (v.y - w.y) ** 2;
   if (l2 === 0) return Math.hypot(p.x - v.x, p.y - v.y);
@@ -728,8 +734,8 @@ const InfiniteCanvas: React.FC = () => {
                   <Arrow
                     key={i}
                     points={shape.points}
-                    stroke={shape.color}
-                    fill={shape.color}
+                    stroke={getCanvasColor(shape.color, theme)}
+                    fill={getCanvasColor(shape.color, theme)}
                     strokeWidth={shape.strokeWidth}
                     pointerLength={16}
                     pointerWidth={16}
@@ -746,7 +752,7 @@ const InfiniteCanvas: React.FC = () => {
                     y={Math.min(shape.points[1], shape.points[3])}
                     width={Math.abs(shape.points[2] - shape.points[0])}
                     height={Math.abs(shape.points[3] - shape.points[1])}
-                    stroke={shape.color}
+                    stroke={getCanvasColor(shape.color, theme)}
                     strokeWidth={shape.strokeWidth}
                     globalCompositeOperation="source-over"
                   />
@@ -759,7 +765,7 @@ const InfiniteCanvas: React.FC = () => {
                     y={(shape.points[1] + shape.points[3]) / 2}
                     radiusX={Math.abs(shape.points[2] - shape.points[0]) / 2}
                     radiusY={Math.abs(shape.points[3] - shape.points[1]) / 2}
-                    stroke={shape.color}
+                    stroke={getCanvasColor(shape.color, theme)}
                     strokeWidth={shape.strokeWidth}
                     globalCompositeOperation="source-over"
                   />
@@ -770,7 +776,7 @@ const InfiniteCanvas: React.FC = () => {
                   <Line
                     key={i}
                     points={shape.points}
-                    stroke={shape.color}
+                    stroke={getCanvasColor(shape.color, theme)}
                     strokeWidth={shape.strokeWidth}
                     tension={0.5}
                     lineCap="round"
@@ -785,7 +791,7 @@ const InfiniteCanvas: React.FC = () => {
               {shapePreview.type === "line" && (
                 <Line
                   points={shapePreview.points}
-                  stroke={shapePreview.color}
+                  stroke={getCanvasColor(shapePreview.color, theme)}
                   strokeWidth={shapePreview.strokeWidth}
                   tension={0}
                   lineCap="round"
@@ -797,8 +803,8 @@ const InfiniteCanvas: React.FC = () => {
               {shapePreview.type === "arrow" && (
                 <Arrow
                   points={shapePreview.points}
-                  stroke={shapePreview.color}
-                  fill={shapePreview.color}
+                  stroke={getCanvasColor(shapePreview.color, theme)}
+                  fill={getCanvasColor(shapePreview.color, theme)}
                   strokeWidth={shapePreview.strokeWidth}
                   pointerLength={16}
                   pointerWidth={16}
@@ -814,7 +820,7 @@ const InfiniteCanvas: React.FC = () => {
                   y={Math.min(shapePreview.points[1], shapePreview.points[3])}
                   width={Math.abs(shapePreview.points[2] - shapePreview.points[0])}
                   height={Math.abs(shapePreview.points[3] - shapePreview.points[1])}
-                  stroke={shapePreview.color}
+                  stroke={getCanvasColor(shapePreview.color, theme)}
                   strokeWidth={shapePreview.strokeWidth}
                   globalCompositeOperation="source-over"
                   dash={[10, 5]}
@@ -826,7 +832,7 @@ const InfiniteCanvas: React.FC = () => {
                   y={(shapePreview.points[1] + shapePreview.points[3]) / 2}
                   radiusX={Math.abs(shapePreview.points[2] - shapePreview.points[0]) / 2}
                   radiusY={Math.abs(shapePreview.points[3] - shapePreview.points[1]) / 2}
-                  stroke={shapePreview.color}
+                  stroke={getCanvasColor(shapePreview.color, theme)}
                   strokeWidth={shapePreview.strokeWidth}
                   globalCompositeOperation="source-over"
                   dash={[10, 5]}
@@ -857,7 +863,7 @@ const InfiniteCanvas: React.FC = () => {
                 y={tb.y}
                 text={tb.text}
                 fontSize={tb.fontSize}
-                fill={tb.color}
+                fill={getCanvasColor(tb.color, theme)}
                 fontFamily={CANVAS_FONT}
                 listening={true}
                 onClick={
@@ -892,7 +898,7 @@ const InfiniteCanvas: React.FC = () => {
               left: editingTb.x * stageScale + stagePos.x,
               top: editingTb.y * stageScale + stagePos.y - 7 / 24 * editingTb.fontSize * stageScale,
               fontSize: editingTb.fontSize * stageScale,
-              color: editingTb.color,
+              color: getCanvasColor(editingTb.color, theme),
               fontFamily: CANVAS_FONT,
               width: Math.max(60, inputWidths[editingTb.id] || 0),
               minWidth: 12,

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -194,6 +194,18 @@ const InfiniteCanvas: React.FC = () => {
   }, [undoBuffer, redoBuffer, lines, textboxes]);
 
   useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === 'p') setActiveTool('pen');
+      if (e.key === 'e') setActiveTool('eraser');
+      if (e.key === 't') setActiveTool('text');
+      if (e.key === 's') setActiveTool('shape');
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  useEffect(() => {
     if (!editingTextboxId) return;
     const preventScroll = (e: Event) => {
       e.preventDefault();

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -5,6 +5,7 @@ import CanvasTextboxInput from "./CanvasTextboxInput";
 import "./InfiniteCanvas.css";
 import DotCanvasOverlay from "./DotCanvasOverlay";
 import { KonvaEventObject } from "konva/lib/Node";
+import { FaMoon, FaSun } from "react-icons/fa";
 
 interface LiveboardAPI {
   autosavePath: () => string;
@@ -68,6 +69,8 @@ getTextWidth.canvas = null as HTMLCanvasElement | null;
 const CANVAS_FONT = "Inter, SF Pro Display, Segoe UI, Roboto, Arial, sans-serif";
 
 const InfiniteCanvas: React.FC = () => {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
   const autosavePath = window.liveboardAPI.autosavePath();
 
   const [cursorPos, setCursorPos] = useState<{ x: number; y: number } | null>(null);
@@ -623,6 +626,32 @@ const InfiniteCanvas: React.FC = () => {
         undo={undo}
         redo={redo}
       />
+      <button
+        className="theme-toggle-btn"
+        aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+        style={{
+          position: "fixed",
+          bottom: 22,
+          right: 22,
+          zIndex: 100,
+          background: "var(--surface-glass)",
+          color: "var(--on-surface)",
+          borderRadius: "50%",
+          width: 40,
+          height: 40,
+          border: "1.5px solid var(--border)",
+          boxShadow: "var(--shadow)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontSize: 22,
+          cursor: "pointer",
+          transition: "background var(--transition), color var(--transition), border var(--transition)"
+        }}
+        onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+      >
+        {theme === "dark" ? FaSun({size: 22}) : FaMoon({size: 22})}
+      </button>
       <DotCanvasOverlay
         stagePos={stagePos}
         stageScale={stageScale}

--- a/src/components/InfiniteCanvas.tsx
+++ b/src/components/InfiniteCanvas.tsx
@@ -150,7 +150,7 @@ const InfiniteCanvas: React.FC = () => {
     } catch (err) {
       console.error("Theme save error:", err);
     }
-  }, [theme]);
+  }, [theme, themeLoaded]);
   
   const initialPinch = useRef<{
     center: { x: number; y: number },

--- a/src/components/Toolbar.css
+++ b/src/components/Toolbar.css
@@ -77,7 +77,6 @@
 .eraser-subtoolbar label {
   font-size: 13px;
   margin-bottom: 4px;
-  color: var(--text-secondary, #222);
 }
 
 .eraser-subtoolbar span {

--- a/src/components/Toolbar.css
+++ b/src/components/Toolbar.css
@@ -21,6 +21,7 @@
   isolation: isolate;
 }
 
+
 @media (max-width: 700px) {
   .toolbar {
     flex-direction: column;
@@ -29,11 +30,22 @@
     min-width: 0;
     gap: 1rem;
   }
+  .pen-subtoolbar,
+  .shape-subtoolbar,
+  .text-subtoolbar,
+  .eraser-subtoolbar {
+    min-width: 0;
+    padding: 8px 6px;
+  }
+  .eraser-subtoolbar input[type="range"] {
+    width: 80px;
+  }
 }
 
 .pen-subtoolbar,
 .shape-subtoolbar,
-.text-subtoolbar {
+.text-subtoolbar,
+.eraser-subtoolbar {
   position: fixed;
   background: var(--surface-glass);
   backdrop-filter: blur(12px) saturate(160%);
@@ -60,4 +72,33 @@
 
 .shapes {
   margin-bottom: 6px;
+}
+
+.eraser-subtoolbar label {
+  font-size: 13px;
+  margin-bottom: 4px;
+  color: var(--text-secondary, #222);
+}
+
+.eraser-subtoolbar span {
+  font-size: 14px;
+  min-width: 28px;
+  text-align: right;
+}
+
+.eraser-subtoolbar button {
+  margin-top: 8px;
+  background: #ff5e5e;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 16px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.07);
+  transition: background 0.15s;
+}
+.eraser-subtoolbar button:hover {
+  background: #e04747;
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -31,9 +31,19 @@ interface ToolbarProps {
   clearCanvas: () => void;
   undo: () => void;
   redo: () => void;
+  theme: "light" | "dark";
+  getCanvasColor: (color: string, theme: "light" | "dark") => string;
 }
 
-const Toolbar = ({ activeTool, setTool, penColor, setPenColor, penThickness, setPenThickness, selectedShape, setSelectedShape, textFontSize, setTextFontSize, eraserRadius, setEraserRadius, clearCanvas, undo, redo }: ToolbarProps) => {
+function getBorderColor(color: string, theme: "light" | "dark") {
+  const isBlack = color === "#333" || color === "#000" || color.toLowerCase() === "black";
+  const isWhite = color === "#fff" || color.toLowerCase() === "white";
+  if (theme === "dark" && isBlack) return "#fff";
+  if (theme === "dark" && isWhite) return "#333";
+  return color;
+}
+
+const Toolbar = ({ activeTool, setTool, penColor, setPenColor, penThickness, setPenThickness, selectedShape, setSelectedShape, textFontSize, setTextFontSize, eraserRadius, setEraserRadius, clearCanvas, undo, redo, theme, getCanvasColor }: ToolbarProps) => {
   const [showPenOptions, setShowPenOptions] = useState(false);
   const [subToolbarPos, setSubToolbarPos] = useState<{top: number, left: number}>({top: 0, left: 0});
   const penButtonRef = useRef<HTMLButtonElement>(null);
@@ -246,8 +256,8 @@ const Toolbar = ({ activeTool, setTool, penColor, setPenColor, penThickness, set
                 key={color}
                 className="color-btn"
                 style={{
-                  background: color,
-                  border: color === penColor ? "2px solid #333" : "2px solid #fff",
+                  background: getCanvasColor(color, theme),
+                  border: "2px solid " + getBorderColor(color === penColor ? "#333" : "#fff", theme),
                 }}
                 onClick={() => setPenColor(color)}
               />
@@ -259,7 +269,7 @@ const Toolbar = ({ activeTool, setTool, penColor, setPenColor, penThickness, set
                 key={thick}
                 className="thickness-btn"
                 style={{
-                  border: thick === penThickness ? "2px solid #333" : "2px solid #ffffff00",
+                  border: "2px solid " + getBorderColor(thick === penThickness ? "#333" : "#ffffff00", theme),
                 }}
                 onClick={() => setPenThickness(thick)}
               >
@@ -268,7 +278,7 @@ const Toolbar = ({ activeTool, setTool, penColor, setPenColor, penThickness, set
                     width: thick,
                     height: thick,
                     borderRadius: "50%",
-                    background: penColor,
+                    background: getCanvasColor(penColor, theme),
                     margin: "auto",
                   }}
                 />
@@ -352,8 +362,8 @@ const Toolbar = ({ activeTool, setTool, penColor, setPenColor, penThickness, set
                 key={color}
                 className="color-btn"
                 style={{
-                  background: color,
-                  border: color === penColor ? "2px solid #333" : "2px solid #fff",
+                  background: getCanvasColor(color, theme),
+                  border: "2px solid " + getBorderColor(color === penColor ? "#333" : "#fff", theme),
                 }}
                 onClick={() => setPenColor(color)}
               />
@@ -392,8 +402,8 @@ const Toolbar = ({ activeTool, setTool, penColor, setPenColor, penThickness, set
                   key={color}
                   className="color-btn"
                   style={{
-                    background: color,
-                    border: color === penColor ? "2px solid #333" : "2px solid #fff",
+                    background: getCanvasColor(color, theme),
+                    border: "2px solid " + getBorderColor(color === penColor ? "#333" : "#fff", theme),
                   }}
                   onClick={() => setPenColor(color)}
                 />

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,25 @@ body {
   margin: 0;
   min-height: 100vh;
 }
+
+.theme-toggle-btn {
+  position: fixed;
+  top: 18px;
+  right: 22px;
+  z-index: 100;
+  background: var(--surface-glass);
+  backdrop-filter: blur(12px) saturate(160%);
+  -webkit-backdrop-filter: blur(12px) saturate(160%);
+  color: var(--on-surface);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  border: 1.5px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), border var(--transition);
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -12,3 +12,18 @@
   --toolbar-height: 44px;
   --transition: 0.16s cubic-bezier(.4,0,.2,1);
 }
+
+:root[data-theme="dark"] {
+  --background: #181a1b;
+  --surface: #222326;
+  --surface-glass: rgba(34,35,38,0.7);
+  --on-surface: #f8fafd;
+  --on-surface-muted: #b0b6c8;
+  --primary: #4f8cff;
+  --primary-accent: #243c5e;
+  --border: #2b2f35;
+  --shadow: 0 4px 32px 0 rgba(20, 30, 40, 0.25);
+  --radius: 16px;
+  --toolbar-height: 44px;
+  --transition: 0.16s cubic-bezier(.4,0,.2,1);
+}


### PR DESCRIPTION
In this Pull Request two key features have been added to Liveboard. The first of these is dark mode - this really improves the user experience for users who use a dark theme for their computer. All necessary updates have been made, so that black text and drawings become white to remain visible in dark mode. The second key update is autosaves. Every change is autosaved to an app log folder, which allows the app to automatically reload the last canvas when the app/computer is restarted. To prevent this from becoming annoying, a `Clear All` button has been added to the eraser toolbar.